### PR TITLE
Add Django Debug for Local Development + PostgreSQL DB

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,4 +22,4 @@ COPY . /code/
 
 EXPOSE 8000
 
-CMD ["gunicorn", "--bind", ":8000", "--workers", "1", "skieasy.wsgi"]
+CMD [ "./startup.sh" ]

--- a/fly.toml
+++ b/fly.toml
@@ -1,4 +1,4 @@
-# fly.toml file generated for skieasy on 2023-04-02T16:13:36-04:00
+# fly.toml file generated for skieasy on 2023-04-09T09:28:53-04:00
 
 app = "skieasy"
 kill_signal = "SIGINT"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,9 @@
 asgiref==3.6.0
+dj-database-url==1.3.0
 Django==4.1.7
 django-debug-toolbar==4.0.0
 gunicorn==20.1.0
+psycopg2-binary==2.9.6
 sqlparse==0.4.3
+typing_extensions==4.5.0
 tzdata==2023.3

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
 asgiref==3.6.0
 Django==4.1.7
+django-debug-toolbar==4.0.0
 gunicorn==20.1.0
 sqlparse==0.4.3
 tzdata==2023.3

--- a/skieasy/settings.py
+++ b/skieasy/settings.py
@@ -12,6 +12,7 @@ https://docs.djangoproject.com/en/4.1/ref/settings/
 
 from pathlib import Path
 import dj_database_url
+import os
 
 # Build paths inside the project like this: BASE_DIR / 'subdir'.
 BASE_DIR = Path(__file__).resolve().parent.parent
@@ -76,16 +77,19 @@ WSGI_APPLICATION = 'skieasy.wsgi.application'
 
 # Database
 # https://docs.djangoproject.com/en/4.1/ref/settings/#databases
-
-DATABASES = {
-    'default': dj_database_url.config(
+DATABASES_AVAILABLE = {
+    'postgres': dj_database_url.config(
         conn_max_age=600,
         conn_health_checks=True,
     ),
     'development': {
         'ENGINE': 'django.db.backends.sqlite3',
         'NAME': BASE_DIR / 'db.sqlite3',
-    }
+    },
+}
+database = os.environ.get('DJANGO_DATABASE', 'development')
+DATABASES = {
+    'default': DATABASES_AVAILABLE[database]
 }
 
 

--- a/skieasy/settings.py
+++ b/skieasy/settings.py
@@ -11,6 +11,7 @@ https://docs.djangoproject.com/en/4.1/ref/settings/
 """
 
 from pathlib import Path
+import dj_database_url
 
 # Build paths inside the project like this: BASE_DIR / 'subdir'.
 BASE_DIR = Path(__file__).resolve().parent.parent
@@ -77,7 +78,11 @@ WSGI_APPLICATION = 'skieasy.wsgi.application'
 # https://docs.djangoproject.com/en/4.1/ref/settings/#databases
 
 DATABASES = {
-    'default': {
+    'default': dj_database_url.config(
+        conn_max_age=600,
+        conn_health_checks=True,
+    ),
+    'development': {
         'ENGINE': 'django.db.backends.sqlite3',
         'NAME': BASE_DIR / 'db.sqlite3',
     }
@@ -128,3 +133,5 @@ DEFAULT_AUTO_FIELD = 'django.db.models.BigAutoField'
 INTERNAL_IPS = [
     '127.0.0.1',
 ]
+
+CSRF_TRUSTED_ORIGINS = ['https://*.fly.dev']

--- a/skieasy/settings.py
+++ b/skieasy/settings.py
@@ -38,6 +38,7 @@ INSTALLED_APPS = [
     'django.contrib.messages',
     'django.contrib.staticfiles',
     'skieasy_app',
+    'debug_toolbar',
 ]
 
 MIDDLEWARE = [
@@ -48,6 +49,7 @@ MIDDLEWARE = [
     'django.contrib.auth.middleware.AuthenticationMiddleware',
     'django.contrib.messages.middleware.MessageMiddleware',
     'django.middleware.clickjacking.XFrameOptionsMiddleware',
+    'debug_toolbar.middleware.DebugToolbarMiddleware',
 ]
 
 ROOT_URLCONF = 'skieasy.urls'
@@ -122,3 +124,7 @@ STATIC_URL = 'static/'
 # https://docs.djangoproject.com/en/4.1/ref/settings/#default-auto-field
 
 DEFAULT_AUTO_FIELD = 'django.db.models.BigAutoField'
+
+INTERNAL_IPS = [
+    '127.0.0.1',
+]

--- a/skieasy/urls.py
+++ b/skieasy/urls.py
@@ -19,4 +19,5 @@ from django.urls import include, path
 urlpatterns = [
     path('admin/', admin.site.urls),
     path('', include('skieasy_app.urls')),
+    path('__debug__/', include('debug_toolbar.urls')),
 ]

--- a/skieasy_app/views.py
+++ b/skieasy_app/views.py
@@ -3,4 +3,4 @@ from django.shortcuts import render
 
 
 def homePageView(request):
-    return HttpResponse("Hello From Django!")
+    return HttpResponse("<body><h1>Hello From SkiEasy!</h1></body>")

--- a/startup.sh
+++ b/startup.sh
@@ -1,0 +1,5 @@
+#!/bin/sh
+
+python manage.py makemigrations
+python manage.py migrate
+gunicorn --bind :8000 --workers 1 skieasy.wsgi


### PR DESCRIPTION
1. Adds Django Debug for local development which should help for creating application. Toolbar will show up as long as HTML sent to request contains a <body>...</body>
2. Adds PostgreSQL Fly.io data persistence for the deployed container that connects and stores data successfully
3. Keep sqlite as default for local development. you can switch to Postgres using DJANGO_DATABASE environment variable