### PR TITLE
Update startup.sh to remove 'makemigrations'

### DIFF
--- a/startup.sh
+++ b/startup.sh
@@ -1,5 +1,4 @@
 #!/bin/sh
 
-python manage.py makemigrations
 python manage.py migrate
 gunicorn --bind :8000 --workers 1 skieasy.wsgi


### PR DESCRIPTION
Essentially, 'makemigrations' shouldn't be run because developers should locally run the command & upload them to the repository. Production Fly.io will then run the committed migrations and keep the DB up-to-sync with the changes being made at the model level. Quoting Django official docs:

"The reason that there are separate commands to make and apply migrations is that you’ll commit migrations to your version control system and ship them with your app; they not only make your development easier, they’re also usable by other developers and in production."