### PR TITLE
Add Overlapping Interval Generator + Small Fixes

### DIFF
--- a/skieasy_app/templates/skieasy_app/home.html
+++ b/skieasy_app/templates/skieasy_app/home.html
@@ -2,7 +2,32 @@
 
 {% block content %}
 
+{% load equipment_extras %}
+
 <div class="columns is-multiline">
+    {% if listings|length == 0 %}
+        <div class="column">
+            <article class="message is-info">
+                <div class="message-header">
+                    <p class="m-0">No Equipment Found!</p>
+                </div>
+                <div class="message-body has-text-centered">
+                    <span class="icon-text is-align-items-center">
+                        <span class="icon is-large">
+                            <i class="fas fa-3x fa-frown-open"></i>
+                        </span>
+                        <span>Dang! We're sorry!</span>
+                    </span>
+                    <br>
+                    <br>
+                    <span>
+                    We weren't able to find any equipment for the given search request. Consider expanding your search using the search bar above, thanks!
+                    </span>
+                </div>
+            </article>
+        </div>
+    {% endif %}
+
     {% for listing in listings %}
         <div class="column is-3-fullhd is-4-widescreen is-half-tablet">
             <div class="card">
@@ -23,7 +48,12 @@
                         <div class="content">
                             <h4>{{ listing.title }}</h4>
                             <p class="subtitle is-5 mb-4"><strong>${{ listing.price }}</strong> day</p>
-                            <p class="mb-1">{{ listing.equipment_listings.first.start_date|date:"M d" }} - {{ listing.equipment_listings.first.end_date|date:"M d" }}</p>
+                            {% if request.GET.start_date or request.GET.end_date%}
+                                {% overlap_generator listing request.GET.start_date request.GET.end_date as overlap%}
+                                <p class="mb-1">{{ overlap.0|date:"M d" }} - {{ overlap.1|date:"M d" }}</p>
+                            {% else %}
+                                <p class="mb-1">{{ listing.equipment_listings.first.start_date|date:"M d" }} - {{ listing.equipment_listings.first.end_date|date:"M d" }}</p>
+                            {% endif %}
                             <p>{{ listing.profile_id.neighborhood }} Area</p>
                             <div class="is-flex is-justify-content-space-around is-flex-wrap-wrap">
                                 <div class="tags has-addons mb-1">

--- a/skieasy_app/templatetags/equipment_extras.py
+++ b/skieasy_app/templatetags/equipment_extras.py
@@ -1,0 +1,43 @@
+from django.utils import timezone
+from django import template
+import pytz
+
+register = template.Library()
+
+@register.simple_tag
+def overlap_generator(equipment, start_date, end_date):
+    '''
+    Generates the appropriate overlap for searched equipment.
+
+    Assume equipment_listing intervals do NOT overlap.
+    '''
+    overlap_start = ""
+    overlap_end = ""
+    intervals = [(obj.start_date, obj.end_date) for obj in equipment.equipment_listings.all()]
+    intervals = sorted(intervals, key=lambda x: x[0])
+    if start_date and end_date:
+        start_date = timezone.datetime.strptime(start_date, '%Y-%m-%d')
+        start_date = pytz.utc.localize(start_date)
+        end_date = timezone.datetime.strptime(end_date, '%Y-%m-%d')
+        end_date = pytz.utc.localize(end_date)
+        for (start_int, end_int) in intervals:
+            if start_int <= end_date and end_int >= start_date:
+                overlap_start = max(start_int, start_date)
+                overlap_end = min(end_int, end_date)
+                break;
+    elif start_date:
+        start_date = timezone.datetime.strptime(start_date, '%Y-%m-%d')
+        start_date = pytz.utc.localize(start_date)
+        for (start_int, end_int) in intervals:
+            if end_int >= start_date and start_int <= start_date:
+                overlap_start = max(start_int, start_date)
+                overlap_end = end_int
+                break;
+    elif end_date:
+        end_date = timezone.datetime.strptime(end_date, '%Y-%m-%d')
+        end_date = pytz.utc.localize(end_date)
+        for (start_int, end_int) in intervals:
+            if end_int >= end_date and start_int <= end_date:
+                overlap_start = start_int
+                overlap_end = min(end_int, end_date)
+    return (overlap_start, overlap_end)

--- a/skieasy_app/views.py
+++ b/skieasy_app/views.py
@@ -1,3 +1,4 @@
+from django.db.models import Count
 from skieasy_app.models import EquipmentImage
 from skieasy_app.forms import ProfileForm, EquipmentListingForm, EquipmentForm
 from skieasy_app.models import Profile, Equipment, EquipmentListing
@@ -11,7 +12,6 @@ from datetime import datetime
 
 from django.contrib.auth.decorators import login_required
 from django.template import loader
-from django.contrib.auth import logout
 from django.contrib.auth.mixins import LoginRequiredMixin
 from django_filters.views import FilterView
 
@@ -27,6 +27,15 @@ class HomeView(LoginRequiredMixin, FilterView):
     context_object_name = "listings"
     paginate_by = 12
     ordering = ['profile_id']
+
+    def get_queryset(self):
+        queryset = super().get_queryset()
+        queryset = (
+            queryset
+            .annotate(listing_count=Count('equipment_listings'))
+            .filter(listing_count__gt=0)
+        )
+        return queryset
 
 
 @login_required


### PR DESCRIPTION
This PR resolves several outstanding issues:

1. Adds a message if the search result yields no results

![image](https://user-images.githubusercontent.com/59340807/235829419-f085f098-8670-4374-ba9e-a617a62ca6fa.png)

2. Adds functionality such that start_date and end_date can be used and the home page will display the correct interval of overlapping time between the request and equipment listing that is available

![image](https://user-images.githubusercontent.com/59340807/235829499-d02c9824-7f2c-48a1-ac0f-15b56cf88d09.png)

![image](https://user-images.githubusercontent.com/59340807/235829546-e9bdb21f-fdf5-4aac-9f9c-f008fef046a7.png)

![image](https://user-images.githubusercontent.com/59340807/235829557-49d80235-0b91-4e7a-954f-86eabaa3ecf5.png)

![image](https://user-images.githubusercontent.com/59340807/235829578-ba4652a4-3652-47c3-9206-69390d9e9525.png)


3. Adds filter s.t. only equipment with equipment_listings gets shown on the Home page

![image](https://user-images.githubusercontent.com/59340807/235829668-7c7ed759-3dac-4c99-95b5-bf124339313d.png)

![image](https://user-images.githubusercontent.com/59340807/235829676-e67a2122-f12f-4d44-affa-898c33530856.png)

![image](https://user-images.githubusercontent.com/59340807/235829693-10d1df9f-e79c-408b-a88f-7795ea06d4fc.png)